### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,38 @@
+# Cloud Agent base image for CoreDeck.
+#
+# CoreDeck is a C++20 desktop app (CMake + Ninja, Dear ImGui + GLFW + OpenGL).
+# This image installs the stable system toolchain and the GL/X11 development
+# libraries the app links against, plus a headless software-rendering stack
+# (Xvfb + Mesa llvmpipe) so the GUI can be launched and exercised without a
+# physical display. Repository-specific work (submodules + build) happens in
+# the install step, not here.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        curl \
+        build-essential \
+        cmake \
+        ninja-build \
+        pkg-config \
+        libcurl4-openssl-dev \
+        libgl1-mesa-dev \
+        libx11-dev \
+        libxrandr-dev \
+        libxinerama-dev \
+        libxcursor-dev \
+        libxi-dev \
+        libxext-dev \
+        libglu1-mesa \
+        libgl1-mesa-dri \
+        xvfb \
+        x11-utils \
+        mesa-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+USER ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,14 @@
+{
+  "name": "CoreDeck",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "xvfb",
+      "command": "Xvfb :99 -screen 0 1280x960x24"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Idempotent repository bootstrap for CoreDeck Cloud Agents.
+# Runs from /workspace after the repository is checked out.
+set -euo pipefail
+
+# Only the submodules the default (Sentry-disabled) build needs. This skips the
+# heavy sentry-native tree and reflect-cpp's bundled vcpkg, which are not used
+# unless COREDECK_SENTRY_DSN is set. Non-recursive on purpose.
+git submodule update --init \
+    extern/imgui \
+    extern/glfw \
+    extern/reflect-cpp \
+    extern/tinyfiledialogs \
+    extern/catch2 \
+    extern/miniz
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCOREDECK_BUILD_TESTS=ON
+cmake --build build --parallel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed [Cursor Cloud Agent](https://cursor.com/docs/cloud-agent/setup) environment so CoreDeck can be built, tested, and run end-to-end in an isolated cloud VM. The config is version-controlled under `.cursor/`, so it follows branches/PRs and requires no dashboard setup.

CoreDeck is a C++20 desktop app (CMake + Ninja, Dear ImGui + GLFW + OpenGL). The environment provides the stable system toolchain and GL/X11 libraries it links against, plus a headless software-rendering stack (Xvfb + Mesa llvmpipe) so the GUI can be launched without a physical display.

## Changes

- **`.cursor/Dockerfile`** — Ubuntu 24.04 base with `build-essential`, `cmake`, `ninja-build`, the CI-required GL/X11 dev libraries (`libgl1-mesa-dev`, `libx11-dev`, `libxrandr-dev`, `libxinerama-dev`, `libxcursor-dev`, `libxi-dev`, `libxext-dev`, `libcurl4-openssl-dev`), and a headless GUI stack (`xvfb`, `libgl1-mesa-dri`, `mesa-utils`, `x11-utils`). A clean `ubuntu:24.04` + `build-essential` makes the default `c++` resolve to `g++`, avoiding the `clang → gcc-14 → missing libstdc++` pitfall present on some default images.
- **`.cursor/install.sh`** — idempotent bootstrap that initializes only the submodules the default (Sentry-disabled) build needs — skipping the heavy `sentry-native` tree and `reflect-cpp`'s bundled `vcpkg` — then configures and builds `Release` with `-DCOREDECK_BUILD_TESTS=ON`.
- **`.cursor/environment.json`** — wires the Dockerfile + install step, runs as user `ubuntu`, and starts `Xvfb` on display `:99` as a persistent terminal for GUI work.

## Validation

Validated twice independently on Ubuntu 24.04 x86_64 using the exact package set and commands codified above (once directly, once by a separate agent that reproduced the Dockerfile's package set on a clean toolchain):

| Check | Result |
| --- | --- |
| Fresh bootstrap (`install.sh` from de-initialized submodules) | Build succeeds in ~42s |
| Install idempotence | Second run: `ninja: no work to do` |
| Test suite (`ctest`) | 79/79 passed (network test skipped by design) |
| GUI end-to-end (Xvfb + llvmpipe) | Onboarding wizard → SDK path validation → main app screen (AVD list, options, live resource panel, log viewer) |

Note: the actual Docker image build + `xvfb` terminal auto-start in a provisioned pod could not be exercised from the setup run (no in-VM Docker, and the greenfield build API doesn't accept a Dockerfile config). The configuration's substance is fully validated above; the image build can be confirmed by starting a normal Cloud Agent on this branch or triggering a build once the environment is recognized.

### GUI demo

Launched the built binary headlessly and drove the full onboarding flow into the main application:

[coredeck_onboarding_to_main_demo.mp4](https://cursor.com/agents/bc-35d2d20f-bc47-4552-86c9-c614d5bc1082/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoredeck_onboarding_to_main_demo.mp4)

[SDK path live validation](https://cursor.com/agents/bc-35d2d20f-bc47-4552-86c9-c614d5bc1082/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoredeck_sdk_path_validation.png)
[CoreDeck main screen](https://cursor.com/agents/bc-35d2d20f-bc47-4552-86c9-c614d5bc1082/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoredeck_main_screen.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d2d20f-bc47-4552-86c9-c614d5bc1082?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d2d20f-bc47-4552-86c9-c614d5bc1082&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

